### PR TITLE
Missing vue loader plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 
 var path = require('path')
 var webpack = require('webpack')
+const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
   entry: './src/index.ts',
@@ -42,6 +43,9 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new VueLoaderPlugin()
+  ],
   resolve: {
     extensions: ['.ts', '.js', '.vue', '.json'],
     alias: {


### PR DESCRIPTION
https://vue-loader.vuejs.org/guide/#manual-setup

missing plugin leads to following error.

```
Module parse failed: Unexpected token (38:0)
You may need an appropriate loader to handle this file type.
| 
| 
> .greeting{
|     font-size: 30px;
| }
```